### PR TITLE
Minor tweaks

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,8 @@
 'use strict';
 
 const _ = require('lodash'),
-  multiplexTemplates = require('multiplex-templates'),
-  handlebars = require('handlebars'),
   express = require('express'),
+  handlebars = require('handlebars'),
   streamPages = require('./lib/stream-pages'),
   Filters = require('./lib/filters'),
   Transforms = require('./lib/transforms'),
@@ -43,15 +42,15 @@ function standardText(amphora) {
  */
 function standardXML(amphora, opts) {
   const filters = Filters(amphora),
-    transforms = Transforms(amphora);
-
-  opts = opts || {};
-
-  _.defaults(opts, {
-    prelude: DEFAULT_XML_PRELUDE,
-    postlude: DEFAULT_XML_POSTLUDE,
-    engines: handlebars
-  });
+    transforms = Transforms(amphora),
+    finalOpts = _.defaults({}, opts, {
+      prelude: DEFAULT_XML_PRELUDE,
+      postlude: DEFAULT_XML_POSTLUDE,
+      template: 'sitemap',
+      engines: {
+        handlebars: handlebars
+      }
+    });
 
   return (req, res) => {
     res.type('xml');
@@ -59,8 +58,8 @@ function standardXML(amphora, opts) {
       .pipe(filters.published())
       .pipe(filters.public())
       .pipe(transforms.pages.compose(res.locals))
-      .pipe(transforms.pages.toXML(res.locals, multiplexTemplates(opts.engines)))
-      .pipe(transforms.strings.addBookends(opts.prelude, opts.postlude))
+      .pipe(transforms.pages.toXML(res.locals, _.pick(finalOpts, ['template', 'engines'])))
+      .pipe(transforms.strings.addBookends(finalOpts.prelude, finalOpts.postlude))
       .pipe(res);
   };
 }

--- a/lib/transforms.js
+++ b/lib/transforms.js
@@ -3,12 +3,27 @@
 const components = require('amphora').components,
   _ = require('lodash'),
   through2 = require('through2'),
-  throughMap = require('through2-map');
+  throughMap = require('through2-map'),
+  multiplexTemplates = require('multiplex-templates'),
+  handlebars = require('handlebars');
 
+/**
+ * Return a stream transform that converts page objects of the form {pageRef: string, pageData:
+ * object} into XML strings.
+ * @param  {object} locals
+ * @param  {object} opts
+ * @param  {string} opts.template - template to render
+ * @param  {object} opts.engines - engines to use for rendering, e.g. {handlebars: require('handlebars')}
+ * @return {object}
+ */
+function pagesToXML(locals, opts) {
+  const renderOpts = {
+    template: opts && opts.template || 'sitemap',
+    multiplex: multiplexTemplates(opts && opts.engines || handlebars)
+  };
 
-function pagesToXML(locals, multiplex) {
   return throughMap.obj(item => {
-    const cmptXml = getPageXML(item.pageRef, item.pageData, locals, multiplex);
+    const cmptXml = getPageXML(item.pageRef, item.pageData, locals, renderOpts);
 
     return `<url><loc>${item.pageData.url}</loc>${cmptXml}</url>`;
   });
@@ -20,14 +35,13 @@ function pagesToXML(locals, multiplex) {
  * @param  {string} pageRef
  * @param  {object} pageData
  * @param  {object} locals
- * @param  {object} multiplex
+ * @param  {object} renderConf - configuration props for rendering (see getCmptXML)
  * @return {string}
  */
-function getPageXML(pageRef, pageData, locals, multiplex) {
-  const indices = components.getIndices(pageRef, pageData),
-    render = (cmptData, cmptRef) => getCmptXML(cmptRef, cmptData, locals, multiplex);
+function getPageXML(pageRef, pageData, locals, renderConf) {
+  const indices = components.getIndices(pageRef, pageData);
 
-  return _.map(indices.refs, render).join('');
+  return _.map(indices.refs, (cmptData, cmptRef) => getCmptXML(cmptRef, cmptData, locals, renderConf)).join('');
 }
 
 /**
@@ -35,14 +49,16 @@ function getPageXML(pageRef, pageData, locals, multiplex) {
  * @param  {string} cmptRef
  * @param  {object} cmptData
  * @param  {object} locals
- * @param  {object} multiplex
+ * @param  {object} conf - Configuration object (required)
+ * @param  {string} conf.template - Template name to rendering (required)
+ * @param  {string} conf.multiplex - Multiplex to use for rendering (required)
  * @return {string}
  */
-function getCmptXML(cmptRef, cmptData, locals, multiplex) {
-  const template = components.getTemplate(cmptRef, 'sitemap');
+function getCmptXML(cmptRef, cmptData, locals, conf) {
+  const template = components.getTemplate(cmptRef, conf.template);
 
   if (template) {
-    return multiplex.render(template, _.assign(cmptData, {locals: locals}));
+    return conf.multiplex.render(template, _.assign(cmptData, {locals: locals}));
   }
 }
 
@@ -81,7 +97,8 @@ function addBookends(prelude, postlude) {
 /**
  * Stream transform for composing pages. Each item is expected to be of the form
  * {pageData: object}. The `pageData` value will be composed, i.e. it will included
- * all of the page's component data, just like the page's JSON endpoint.
+ * all of the page's component data, just like the page's JSON endpoint. If composing
+ * a page fails, it is removed from the stream.
  * @param  {object} amphora
  * @param  {object} locals
  * @return {object}
@@ -96,7 +113,7 @@ function composePages(amphora, locals) {
         cb(null, item);
       })
       .catch((err)=>{
-        console.log(err);
+        console.log(err, err.stack);
         cb();
       });
   });


### PR DESCRIPTION
[Trello](https://trello.com/c/lS3YTHRw/7-thecut-com-cut-news-sitemap) and [Trello](https://trello.com/c/deJDnM1D/25-thecut-com-articles-xml-sitemap)

* Allow consumer to pass `template` to `standardXML` and related functions for rendering templates that are not `sitemap`.
* Refactor so that objects passed into functions do not get mutated by `_.defaults`
* Consolidate test functions